### PR TITLE
I11 - Add a general Email module

### DIFF
--- a/workflows/Utility/modules/Email/.gitignore
+++ b/workflows/Utility/modules/Email/.gitignore
@@ -1,0 +1,1 @@
+credentials.json

--- a/workflows/Utility/modules/Email/config/config.yaml
+++ b/workflows/Utility/modules/Email/config/config.yaml
@@ -1,0 +1,16 @@
+input_namespace:
+  credentials: "credentials"
+  trigger: "trigger"
+output_namespace: "out"
+params:
+  Credentials:
+    Filename: "credentials.json"
+  Trigger:
+    Filename: "touch"
+  Server:
+    "SMTP Server": "smtp.gmail.com"
+    "SMTP Port": 587
+  Message:
+    Subject: "[GRAPEVNE] Workflow Alert"
+    Body: "Your workflow triggered an email alert."
+    Recipients: "email1@example.com, email2@example.com"

--- a/workflows/Utility/modules/Email/config/config_test.yaml
+++ b/workflows/Utility/modules/Email/config/config_test.yaml
@@ -1,6 +1,6 @@
 input_namespace:
   credentials: "credentials"
-  send: "trigger"
+  send: "send"
   shutdown: "shutdown"
   attachments: "attachments"
 output_namespace: "out"
@@ -15,11 +15,12 @@ params:
     Body: "Your workflow triggered an email alert."
     Recipients: "example@email.com"
     Attachments:
-      - "File_1.txt"
+      - "File_?.txt"
+      - "Filename.txt"
   Triggers:
     "Send email": "touch"
     "Shutdown": "touch"
   Behaviour:
-    "Check triggers interval (secs)": 5
+    "Check triggers interval (secs)": 2
     "Allow multiple emails": true
     "Shutdown timeout": 0

--- a/workflows/Utility/modules/Email/results/attachments/File_1.txt
+++ b/workflows/Utility/modules/Email/results/attachments/File_1.txt
@@ -1,0 +1,2 @@
+this is file 1
+

--- a/workflows/Utility/modules/Email/results/attachments/File_11.txt
+++ b/workflows/Utility/modules/Email/results/attachments/File_11.txt
@@ -1,0 +1,1 @@
+This is file 11

--- a/workflows/Utility/modules/Email/results/attachments/File_2.txt
+++ b/workflows/Utility/modules/Email/results/attachments/File_2.txt
@@ -1,0 +1,1 @@
+This is file 2

--- a/workflows/Utility/modules/Email/results/attachments/Filename.txt
+++ b/workflows/Utility/modules/Email/results/attachments/Filename.txt
@@ -1,0 +1,1 @@
+This is Filename

--- a/workflows/Utility/modules/Email/workflow/Snakefile
+++ b/workflows/Utility/modules/Email/workflow/Snakefile
@@ -1,0 +1,74 @@
+"""Send email
+
+This module sends an email to a list of recipients once the input folder contains the
+file 'touch', which indicates that the previous steps have been completed. Credentials
+should be stored and provided in a separate (local) file and connected to this module.
+Credentials should be provided as a JSON file containing the keys 'username' and
+'password' at the top level for SMTP server access, e.g. a file `credentials.json`:
+{
+    "username": "myusername",
+    "password": "mypassword"
+}
+
+It is recommended that you do not use your personal email account for this purpose.
+Consider creating a new email account. For Gmail, you will need to enable 2FA login and
+create an "app password". Use the app password in your credentials file.
+
+Params:
+    SMTP Server (str): The SMTP server to use.
+    SMTP Port (int): The port to use for the SMTP server.
+    Subject (str): The subject of the email.
+    Body (str): The body of the email.
+    Recipients (list[str]): A comma separated list of email addresses to send the
+        email to.
+"""
+configfile: "config/config.yaml"
+
+credentials_path = config["input_namespace"]["credentials"]
+credentials_file=config["params"]["Credentials"]["Filename"]
+
+trigger_path=config["input_namespace"]["trigger"]
+trigger_file=config["params"]["Trigger"]["Filename"]
+
+outdir=config["output_namespace"]
+workflow_srcdir = srcdir('')
+
+
+def script(name=""):
+    """Return the path to a script (supports local and/or remote execution modes)"""
+    import os
+    from snakemake.remote import AUTO
+
+    try:
+        return AUTO.remote('/'.join([workflow_srcdir, "scripts", name]))
+    except TypeError:
+        import os
+        return os.path.join(workflow_srcdir, "scripts", name)
+
+
+rule email:
+    input:
+        credentials=f"results/{credentials_path}/{credentials_file}",
+        trigger=f"results/{trigger_path}/{trigger_file}",
+        scriptfile=script("sendmail.py"),
+    output:
+        f"results/{outdir}/touch",
+    params:
+        SMTP_Server=config["params"]["Server"]["SMTP Server"],
+        SMTP_Port=config["params"]["Server"]["SMTP Port"],
+        Subject=config["params"]["Message"]["Subject"],
+        Body=config["params"]["Message"]["Body"],
+        Recipients=config["params"]["Message"]["Recipients"],
+    conda:
+        "envs/conda.yaml",
+    shell:
+        """
+        python {input.scriptfile} \
+            --credentials-file="{input.credentials}" \
+            --smtp-server="{params.SMTP_Server}" \
+            --smtp-port={params.SMTP_Port} \
+            --subject="{params.Subject}" \
+            --body="{params.Body}" \
+            --recipients="{params.Recipients}"
+        touch {output}
+        """

--- a/workflows/Utility/modules/Email/workflow/Snakefile
+++ b/workflows/Utility/modules/Email/workflow/Snakefile
@@ -1,26 +1,19 @@
 """Send email
 
-This module sends an email to a list of recipients once the input folder contains the
-file 'touch', which indicates that the previous steps have been completed. Credentials
-should be stored and provided in a separate (local) file and connected to this module.
-Credentials should be provided as a JSON file containing the keys 'username' and
-'password' at the top level for SMTP server access, e.g. a file `credentials.json`:
+This module sends an email to a list of recipients once the input folder contains the file 'touch', which indicates that the previous steps have been completed. Credentials should be stored and provided in a separate (local) file and connected to this module. Credentials should be provided as a JSON file containing the keys 'username' and 'password' at the top level for SMTP server access, e.g. a file `credentials.json`:
 {
     "username": "myusername",
     "password": "mypassword"
 }
 
-It is recommended that you do not use your personal email account for this purpose.
-Consider creating a new email account. For Gmail, you will need to enable 2FA login and
-create an "app password". Use the app password in your credentials file.
+It is recommended that you do not use your personal email account for this purpose. Consider creating a new email account. For Gmail, you will need to enable 2FA login and create an "app password". Use the app password in your credentials file.
 
 Params:
     SMTP Server (str): The SMTP server to use.
     SMTP Port (int): The port to use for the SMTP server.
     Subject (str): The subject of the email.
     Body (str): The body of the email.
-    Recipients (list[str]): A comma separated list of email addresses to send the
-        email to.
+    Recipients (list[str]): A comma separated list of email addresses to send the email to.
 """
 configfile: "config/config.yaml"
 

--- a/workflows/Utility/modules/Email/workflow/Snakefile
+++ b/workflows/Utility/modules/Email/workflow/Snakefile
@@ -8,60 +8,184 @@ This module sends an email to a list of recipients once the input folder contain
 
 It is recommended that you do not use your personal email account for this purpose. Consider creating a new email account. For Gmail, you will need to enable 2FA login and create an "app password". Use the app password in your credentials file.
 
+Note that this module will wait until a 'shutdown' trigger is found before exiting (or a 'send' trigger if 'Allow multiple emails' is set to False). For this reason it is important to run the workflow in a multi-core environment to prevent blocking the workflow (i.e. run snakemake with '--cores n' with n>1).
+
+Inputs:
+    credentials: The path to the credentials file.
+    send: The path to the trigger file.
+    shutdown: The path to the shutdown trigger file.
+    attachments: The path to the attachments.
+
 Params:
-    SMTP Server (str): The SMTP server to use.
-    SMTP Port (int): The port to use for the SMTP server.
-    Subject (str): The subject of the email.
-    Body (str): The body of the email.
-    Recipients (list[str]): A comma separated list of email addresses to send the email to.
+    Credentials:
+        Filename (str): The name of the credentials file.
+    Server:
+        SMTP Server (str): The SMTP server to use.
+        SMTP Port (int): The port to use for the SMTP server.
+    Message:
+        Subject (str): The subject of the email.
+        Body (str): The body of the email.
+        Recipients (str): A comma separated list of email addresses to send the email to.
+        Attachments (list[str]): A list of filenames to attach to the email.
+    Triggers:
+        Send email (str): The name of the trigger file.
+        Shutdown (str): The name of the shutdown trigger file.
+    Behaviour:
+        Check triggers interval (secs) (int): The interval at which to check for triggers.
+        Allow multiple emails (bool): Whether to monitor for subsequent send triggers.
+        Shutdown timeout (int): The maximum time to wait before shutting down the module. Set to 0 to disable.
 """
 configfile: "config/config.yaml"
 
-credentials_path = config["input_namespace"]["credentials"]
-credentials_file=config["params"]["Credentials"]["Filename"]
+import time
+import json
+import glob
+import importlib.util
+from pathlib import Path
 
-trigger_path=config["input_namespace"]["trigger"]
-trigger_file=config["params"]["Trigger"]["Filename"]
+# Folder mappings
+indirs = config["input_namespace"]
+outdir = config["output_namespace"]
+params = config["params"]
 
-outdir=config["output_namespace"]
-workflow_srcdir = srcdir('')
+# Parameters
+delay_timer = params["Behaviour"]["Check triggers interval (secs)"]
+allow_multiple_emails = params["Behaviour"]["Allow multiple emails"]
+timeout = params["Behaviour"]["Shutdown timeout"]
+
+# Paths
+credentials = (
+    Path("results") / indirs["credentials"] / params["Credentials"]["Filename"]
+)
+send_trigger = Path("results") / indirs["send"] / params["Triggers"]["Send email"]
+shutdown_trigger = Path("results") / indirs["shutdown"] / params["Triggers"]["Shutdown"]
+
+# Developer settings
+test_send = False
+verbose = True
 
 
 def script(name=""):
-    """Return the path to a script (supports local and/or remote execution modes)"""
-    import os
-    from snakemake.remote import AUTO
-
+    """Return the path to a script (detects local or remote execution modes)"""
+    workflow_srcdir = srcdir("")
     try:
-        return AUTO.remote('/'.join([workflow_srcdir, "scripts", name]))
+        from snakemake.remote import AUTO
+
+        return AUTO.remote("/".join([workflow_srcdir, "scripts", name]))
     except TypeError:
-        import os
-        return os.path.join(workflow_srcdir, "scripts", name)
+        return Path(workflow_srcdir) / "scripts" / name
+
+
+def import_module(name, module_file):
+    """Import a module from a file"""
+    spec = importlib.util.spec_from_file_location(name, module_file)
+    lib = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(lib)
+    return lib
+
+
+def get_credentials(filename):
+    with open(filename, "r") as f:
+        creds = json.load(f)
+        return (creds.get("username", ""), creds.get("password", ""))
+
+
+def timed_out(t0):
+    if timeout > 0:
+        return time.time() - t0 > timeout
+    return False
 
 
 rule email:
     input:
-        credentials=f"results/{credentials_path}/{credentials_file}",
-        trigger=f"results/{trigger_path}/{trigger_file}",
+        credentials=credentials,
         scriptfile=script("sendmail.py"),
     output:
         f"results/{outdir}/touch",
     params:
-        SMTP_Server=config["params"]["Server"]["SMTP Server"],
-        SMTP_Port=config["params"]["Server"]["SMTP Port"],
-        Subject=config["params"]["Message"]["Subject"],
-        Body=config["params"]["Message"]["Body"],
-        Recipients=config["params"]["Message"]["Recipients"],
-    conda:
-        "envs/conda.yaml",
-    shell:
-        """
-        python {input.scriptfile} \
-            --credentials-file="{input.credentials}" \
-            --smtp-server="{params.SMTP_Server}" \
-            --smtp-port={params.SMTP_Port} \
-            --subject="{params.Subject}" \
-            --body="{params.Body}" \
-            --recipients="{params.Recipients}"
-        touch {output}
-        """
+        SMTP_Server=params["Server"]["SMTP Server"],
+        SMTP_Port=params["Server"]["SMTP Port"],
+        Subject=params["Message"]["Subject"],
+        Body=params["Message"]["Body"],
+        Recipients=params["Message"]["Recipients"],
+        Attachments=params["Message"]["Attachments"],
+        AttachmentsFolder=f"results/{indirs['attachments']}",
+    run:
+        email_loop(
+            input,
+            output,
+            params,
+            send_trigger,
+            shutdown_trigger,
+            delay_timer,
+            allow_multiple_emails,
+            test_send,
+            verbose,
+        )
+
+
+def email_loop(
+    input,
+    output,
+    params,
+    send_trigger,
+    shutdown_trigger,
+    delay_timer,
+    allow_multiple_emails,
+    test_send,
+    verbose,
+):
+    # Load credentials
+    username, password = get_credentials(input.credentials)
+    sender = username
+    # Import module from script
+    sendmail = import_module("sendmail", input.scriptfile)
+    # Start timer
+    t0 = time.time()
+    # Looping permits the module to send multiple emails (e.g. for monitoring long jobs)
+    while True:
+        # Check for send-email trigger
+        if Path(send_trigger).exists():
+            if verbose:
+                print("Sending email.")
+            # Remove trigger to allow additional calls
+            Path(send_trigger).unlink()
+            # Collate attachments (files can change between triggers due to glob patterns)
+            attachments = []
+            for attachment in params.Attachments:
+                pattern = str(Path(params.AttachmentsFolder) / attachment)
+                attachments.extend(glob.glob(pattern))
+            # Send email
+            if test_send and verbose:
+                print("TEST email (simulating send):")
+                print(f" Subject: {params.Subject}")
+                print(f" Body: {params.Body}")
+                print(f" Recipients: {params.Recipients}")
+                print(f" Attachments: {attachments}")
+            else:
+                sendmail.send_email(
+                    params.SMTP_Server,
+                    params.SMTP_Port,
+                    params.Subject,
+                    params.Body,
+                    sender,
+                    params.Recipients,
+                    username,
+                    password,
+                    attachments,
+                )
+            if not allow_multiple_emails:
+                break
+        else:
+            if verbose:
+                print("Waiting for email trigger...")
+        # Check for shutdown conditions
+        if Path(shutdown_trigger).exists() or timed_out(t0):
+            try:
+                Path(shutdown_trigger).unlink()
+            except FileNotFoundError:
+                pass
+            Path(output[0]).touch()  # Permits snakemake to end the rule gracefully
+            break
+        # Inter-iteration delay
+        time.sleep(delay_timer)

--- a/workflows/Utility/modules/Email/workflow/envs/conda.yaml
+++ b/workflows/Utility/modules/Email/workflow/envs/conda.yaml
@@ -1,0 +1,4 @@
+channels:
+  - bioconda
+dependencies:
+  - python

--- a/workflows/Utility/modules/Email/workflow/envs/conda.yaml
+++ b/workflows/Utility/modules/Email/workflow/envs/conda.yaml
@@ -1,4 +1,0 @@
-channels:
-  - bioconda
-dependencies:
-  - python

--- a/workflows/Utility/modules/Email/workflow/scripts/sendmail.py
+++ b/workflows/Utility/modules/Email/workflow/scripts/sendmail.py
@@ -1,0 +1,62 @@
+import os
+import json
+import smtplib
+import logging
+import argparse
+from email.mime.text import MIMEText
+
+# SMTP username and password can be provided as environment variables (but can be
+# overriden by a credentials file if one is specified)
+EMAIL_USERNAME = os.environ.get("EMAIL_USERNAME", "")
+EMAIL_PASSWORD = os.environ.get("EMAIL_PASSWORD", "")
+
+
+def send_email(
+    server_address: str,
+    server_port: int,
+    subject: str,
+    body: str,
+    sender: str,
+    recipients: list[str],
+    username: str,
+    password: str,
+):
+    if not (subject and body and sender and recipients and password):
+        raise ValueError("All parameters must be provided and non-empty")
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = sender
+    msg['To'] = ', '.join(recipients)
+    with smtplib.SMTP(server_address, server_port) as server:
+        server.starttls()
+        server.login(username, password)
+        server.sendmail(username, recipients, msg.as_string())
+    logging.info("Message sent.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Send an email")
+    parser.add_argument("--credentials-file", type=str, help="The file containing the email credentials")
+    parser.add_argument("--smtp-server", type=str, help="The address of the SMTP server")
+    parser.add_argument("--smtp-port", type=int, help="The port of the SMTP server")
+    parser.add_argument("--subject", type=str, help="The subject of the email")
+    parser.add_argument("--body", type=str, help="The body of the email")
+    parser.add_argument("--recipients", type=str, help="A comma separated list of recipients")
+    args = parser.parse_args()
+    recipients = args.recipients.split(",")
+    if (args.credentials_file):
+        with open(args.credentials_file) as f:
+            credentials = json.load(f)
+            EMAIL_USERNAME = credentials.get('username', "")
+            EMAIL_PASSWORD = credentials.get('password', "")
+    sender = EMAIL_USERNAME
+    send_email(
+        args.smtp_server,
+        args.smtp_port,
+        args.subject,
+        args.body,
+        sender,
+        recipients,
+        EMAIL_USERNAME,
+        EMAIL_PASSWORD
+    )


### PR DESCRIPTION
Module can be used to send emails at various stages of a workflow. Credentials are provided by local file, and email transmission is triggered by the presence/arrival of a trigger-file which can be user configured.

To test the module:
- Pull down this branch
- Create a 'results/credentials/credentials.json' file (in accordance with the `workflow/Snakefile` docstring); note that this replicates a separate module which would like to a local file during normal execution.
- run `snakemake --use-cores 1 --use-conda`

To test the module in grapevne:
- Obtain and build the latest version of [GRAPEVNE](https://github.com/kraemer-lab/GRAPEVNE)
- Pull down this branch
- redirect grapevne to the `workflows` folder in this repo (use the local copy, since the module had not yet been merged in)
- connect the module to some [Local file](https://github.com/kraemer-lab/vneyard/tree/main/workflows/Utility/sources) modules in order to provide credential and trigger files.
