### PR TITLE
(LinkLocalFile) Update to use File (folder+filename) configuration

### DIFF
--- a/workflows/Utility/sources/LinkLocalFile/config/config.yaml
+++ b/workflows/Utility/sources/LinkLocalFile/config/config.yaml
@@ -1,4 +1,6 @@
 input_namespace: null
 output_namespace: "out"
 params:
-  file: "<Full path to local file>"
+  File:
+    Name: "data.csv"
+    Folder: "/data"

--- a/workflows/Utility/sources/LinkLocalFile/config/config_test.yaml
+++ b/workflows/Utility/sources/LinkLocalFile/config/config_test.yaml
@@ -1,0 +1,9 @@
+# Test configuration can be run with the following command:
+#  snakemake --cores 1 --use-conda --configfile config_test.yaml
+# Ensure that `results/in/test.file` exists before running the test.
+input_namespace: null
+output_namespace: "out"
+params:
+  File:
+    Name: "test.file"
+    Folder: "results/in"

--- a/workflows/Utility/sources/LinkLocalFile/workflow/Snakefile
+++ b/workflows/Utility/sources/LinkLocalFile/workflow/Snakefile
@@ -10,25 +10,31 @@ Params:
 configfile: "config/config.yaml"
 import os
 
+# Extract params from config file
+outdir = config["output_namespace"]
 params = config["params"]
-filepath, filename = os.path.split(os.path.abspath(params["file"]))
+
+# Get the full path to the target file
+filename = params["File"]["Name"]
+filepath = params["File"]["Folder"]
+fullfile = os.path.abspath(os.path.join(filepath, filename))
+
+# Get the output directory and the relative path from that directory to the target
+output_dir = os.path.abspath(f"results/{outdir}")
+relpath = os.path.relpath(fullfile, output_dir)
 
 rule copy:
     input:
-        # Requires an absolute path to form the symbolic link
-        expand(
-            "{fullfile}",
-            fullfile=params["file"],
-        )
+        fullfile,
     output:
-        expand(
-            "results/{outdir}/{filename}",
-            outdir=config["output_namespace"],
-            filename=filename,
-        )
+        outfile = f"results/{outdir}/{filename}",
     params:
-        filename=os.path.join(filepath, filename),
+        relpath = relpath,
+    conda:
+        "envs/empty.yaml",
+    log:
+        f"logs/copy_{filename}.log",
     shell:
         """
-        ln -s -f {params.filename} {output[0]}
+        ln -s -f {params.relpath} {output.outfile}
         """

--- a/workflows/Utility/sources/LinkLocalFile/workflow/envs/empty.yaml
+++ b/workflows/Utility/sources/LinkLocalFile/workflow/envs/empty.yaml
@@ -1,0 +1,1 @@
+name: empty


### PR DESCRIPTION
**LinkLocalFile**: Update to use File (folder+filename) configuration

This changes the parameter set for LinkLocalFile from a single 'Filename' to a file and folder combination. This will be treated as a special parameter in GRAPEVNE permitting the use of file selection tools, whilst allowing the `filename` parameter (excluding path) to be passed from one module to another.