### PR TITLE
(New module) Touch

### DIFF
--- a/workflows/Utility/sources/Touch/config/config.yaml
+++ b/workflows/Utility/sources/Touch/config/config.yaml
@@ -1,0 +1,4 @@
+input_namespace: null
+output_namespace: out
+params:
+  Filename: touch

--- a/workflows/Utility/sources/Touch/workflow/Snakefile
+++ b/workflows/Utility/sources/Touch/workflow/Snakefile
@@ -1,0 +1,23 @@
+"""Create an empty file
+
+Create an empty file in the results directory with the name specified in the config file. This is often useful for providing triggers to downstream modules.
+
+Params:
+    Filename (str): The name of the file to create.
+"""
+configfile: "config/config.yaml"
+
+from pathlib import Path
+
+outdir = config["output_namespace"]
+params = config["params"]
+filename = params["Filename"]
+
+rule touch:
+    output:
+        filename = f"results/{outdir}/{filename}",
+    params:
+        outdir = f"results/{outdir}"
+    run:
+        Path(params.outdir).mkdir(parents=True, exist_ok=True)
+        Path(output.filename).touch()


### PR DESCRIPTION
Provide a generic 'touch' module, which acts to trigger other modules/actions.

Snakemake is a file-based system where the create of new files to act as triggers is common. This module add this facility.