### PR TITLE
changed beagle==4.1_21Jan17.6cc.jar to beagle-lib=3.1.2

### DIFF
--- a/workflows/Utility/modules/BEAST/workflow/envs/conda.yml
+++ b/workflows/Utility/modules/BEAST/workflow/envs/conda.yml
@@ -2,5 +2,5 @@ channels:
   - bioconda/label/cf201901
 dependencies:
   - java-jdk==8.0.112
-  - beagle==4.1_21Jan17.6cc.jar
+  - beagle-lib==3.1.2
   - beast==1.10.4


### PR DESCRIPTION
beagle==4.1_21Jan17.6cc.jar ([https://anaconda.org/bioconda/beagle](url)) is actually not the beagle library we want. Rhys did some testing and found that beagle-lib=3.1.2 ([https://bioconda.github.io/recipes/beagle-lib/README.html](url)) is the only one that works.