### PR TITLE
changed beagle==4.1_21Jan17.6cc.jar to beagle-lib=3.1.2 (moved from #29)

### DIFF
--- a/workflows/Utility/modules/BEAST/.test.sh
+++ b/workflows/Utility/modules/BEAST/.test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf results/out
+snakemake --cores 1 --use-conda

--- a/workflows/Utility/modules/BEAST/workflow/envs/conda.yml
+++ b/workflows/Utility/modules/BEAST/workflow/envs/conda.yml
@@ -1,4 +1,5 @@
 channels:
+  - conda-forge
   - bioconda/label/cf201901
 dependencies:
   - java-jdk==8.0.112

--- a/workflows/Utility/modules/BEAST/workflow/envs/conda.yml
+++ b/workflows/Utility/modules/BEAST/workflow/envs/conda.yml
@@ -2,5 +2,5 @@ channels:
   - bioconda/label/cf201901
 dependencies:
   - java-jdk==8.0.112
-  - beagle==4.1_21Jan17.6cc.jar
+  - beagle-lib==3.1.2
   - beast==1.10.4


### PR DESCRIPTION
Moved from [https://github.com/kraemer-lab/vneyard/pull/29](https://github.com/kraemer-lab/vneyard/pull/29)

beagle==4.1_21Jan17.6cc.jar ([https://anaconda.org/bioconda/beagle](https://github.com/kraemer-lab/vneyard/pull/url)) is actually not the beagle library we want. Rhys did some testing and found that beagle-lib=3.1.2 ([https://bioconda.github.io/recipes/beagle-lib/README.html](https://github.com/kraemer-lab/vneyard/pull/url)) is the only one that works.

Now added `.test.sh`