### PR TITLE
(BEAST) Redirect BEAST log file to output namespace

### DIFF
--- a/workflows/Utility/modules/BEAST/workflow/Snakefile
+++ b/workflows/Utility/modules/BEAST/workflow/Snakefile
@@ -50,6 +50,7 @@ if params['save_every']:
             checkpoint=checkpoint_file,
             save_every=params["save_every"],
             opts=params["options"],
+            outdir=f"results/{outdir}",
         log:
             "log/resume_beast.log"
         benchmark:
@@ -68,9 +69,9 @@ if params['save_every']:
                 {input.xml} \
                 > >(tee -a log/stdout.log) 2> >(tee -a log/stderr.log >&2) 
             
-            # Move residual BEAST log files
-            mkdir -p log
-            mv *.txt log
+            # Keep BEAST log files
+            mkdir -p {params.outdir}
+            mv *.txt {params.outdir}
             
             # Signal completion
             touch {output}
@@ -96,6 +97,7 @@ if params['save_every']:
             checkpoint=checkpoint_file,
             save_every=params["save_every"],
             opts=params["options"],
+            outdir=f"results/{outdir}",
         conda:
             "envs/conda.yml"
         shell:
@@ -107,9 +109,9 @@ if params['save_every']:
                 {input.xml} \
                 > >(tee -a log/stdout.log) 2> >(tee -a log/stderr.log >&2) 
 
-            # Move residual BEAST log files
-            mkdir -p log
-            mv *.txt log
+            # Keep BEAST log files
+            mkdir -p {params.outdir}
+            mv *.txt {params.outdir}
 
             # Signal completion
             touch {output}


### PR DESCRIPTION
BEAST output ('log') files were being redirected to the 'logs' folder, instead of being made available to downstream modules via the `output_namespace` folder.