### PR TITLE
Remove defaults channel from CI

### DIFF
--- a/.github/workflows/pull_tests.yaml
+++ b/.github/workflows/pull_tests.yaml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniconda-version: "latest"
+          miniforge-version: latest
           auto-update-conda: true
           python-version: 3.11
 


### PR DESCRIPTION
Remove `defaults` channel from conda during workflow testing; do this by switching from miniconda to miniforge in CI (which does not install `defaults`, or other paid-use channels supplied by anaconda when installed).
See #41 #42 