### PR TITLE
Remove defaults channel from module conda configs

### DIFF
--- a/workflows/EPI/modules/EpiLine/workflow/envs/epiline.yaml
+++ b/workflows/EPI/modules/EpiLine/workflow/envs/epiline.yaml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - r
   - r-devtools

--- a/workflows/EPI/modules/Subsampler_Brito/workflow/envs/aggregator.yaml
+++ b/workflows/EPI/modules/Subsampler_Brito/workflow/envs/aggregator.yaml
@@ -1,7 +1,6 @@
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - pip
   - pip:

--- a/workflows/EPI/modules/Subsampler_Brito/workflow/envs/correct_bias.yaml
+++ b/workflows/EPI/modules/Subsampler_Brito/workflow/envs/correct_bias.yaml
@@ -1,7 +1,6 @@
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - pip
   - pip:

--- a/workflows/EPI/modules/Subsampler_Brito/workflow/envs/genome_matrix.yaml
+++ b/workflows/EPI/modules/Subsampler_Brito/workflow/envs/genome_matrix.yaml
@@ -1,7 +1,6 @@
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - pip
   - pip:

--- a/workflows/EPI/modules/Subsampler_Brito/workflow/envs/subsampler.yaml
+++ b/workflows/EPI/modules/Subsampler_Brito/workflow/envs/subsampler.yaml
@@ -1,7 +1,6 @@
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
   - pip
   - pip:

--- a/workflows/EPI/sources/EpiLine_Simulation/workflow/envs/epiline.yaml
+++ b/workflows/EPI/sources/EpiLine_Simulation/workflow/envs/epiline.yaml
@@ -1,6 +1,5 @@
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - r
   - r-devtools


### PR DESCRIPTION
Remove `defaults` from conda environment files (see #41 ). CI has already been updated (see #43 ).

Resolves #41 