### PR TITLE
Add manifest action

### DIFF
--- a/.github/workflows/manifest.yaml
+++ b/.github/workflows/manifest.yaml
@@ -1,0 +1,29 @@
+name: Update Manifest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Update manifest
+        run: python manifest.py
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add manifest.json
+          git commit -m 'Update manifest file after merge to main'
+          git push
+        env:
+          # Provide a GitHub token to allow pushing changes
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/manifest.py
+++ b/manifest.py
@@ -1,0 +1,46 @@
+import os
+import json
+import gzip
+
+FILENAME = 'manifest'
+COMPRESSION = False
+
+reject_list = [
+    '.snakemake',
+    '.git',
+    '.github',
+]
+
+
+def create_folder_structure_json(path):
+    """Produces a folder hierarchy structure that mimics the github API format"""
+    result = {
+        'name': os.path.basename(path),
+        'type': 'folder',
+        'children': [],
+    }
+
+    # Check if the path is a directory
+    if not os.path.isdir(path):
+        return result
+
+    # Iterate over the entries in the directory
+    for entry in os.listdir(path):
+        entry_path = os.path.join(path, entry)
+        if os.path.isdir(entry_path) and entry not in reject_list:
+            result['children'].append(create_folder_structure_json(entry_path))
+        else:
+            result['children'].append({'name': entry, 'type': 'file'})
+
+    return result
+
+
+folder_json = create_folder_structure_json('.')
+folder_json_str = json.dumps(folder_json)
+
+if COMPRESSION:
+    with gzip.open(f'{FILENAME}.json.gz', 'wt', encoding='UTF-8') as zipfile:
+        zipfile.write(folder_json_str)
+else:
+    with open(f'{FILENAME}.json', 'wt', encoding='UTF-8') as f:
+        f.write(folder_json_str)

--- a/manifest.py
+++ b/manifest.py
@@ -2,8 +2,8 @@ import os
 import json
 import gzip
 
-FILENAME = 'manifest'
-COMPRESSION = False
+FILENAME = os.environ.get('MANIFEST_FILENAME', 'manifest')
+COMPRESSION = os.environ.get('MANIFEST_COMPRESSION', 'False').lower() == 'true'
 
 reject_list = [
     '.snakemake',


### PR DESCRIPTION
Add a github action that automatically updates a central manifest file each time there is a push to `main`. This will form a recommended action to include in GRAPEVNE repositories as it provides a single reference file with the file structure of the repository. Alternatives included:
1) users cloning the repository (undesirable as the repository grow in size, especially where only one or two modules are required)
2) github API calls, which can produce a 403 rate limit exceeded error when repeatedly polled (this is especially problematic in group sessions routing through the same network). Access to files through `raw.githubusercontent.com` is not rate limited in this way, thereby circumventing the issue entirely.

GRAPEVNE support for (uncompressed) `manifest.json` files was already enabled in [#287](https://github.com/kraemer-lab/GRAPEVNE/pull/287). GRAPEVNE will attempt to first load a `manifest.json` file, and fallback to the github API if this is not found. This PR adds automatic manifest updating on the repository side through an easy to install github action + python script.

Verification: This branch has been merged into `main` on https://github.com/jsbrittain/vneyard for testing and verification.

Resolves https://github.com/kraemer-lab/GRAPEVNE/issues/205