### PR TITLE
(AssignSerotypeAndGenotypeNextclade) fixes for remote resources

### DIFF
--- a/workflows/Dengue/modules/AssignSerotypeAndGenotypeNextclade/workflow/Snakefile
+++ b/workflows/Dengue/modules/AssignSerotypeAndGenotypeNextclade/workflow/Snakefile
@@ -6,15 +6,29 @@ from grapevne_helper import import_grapevne
 grapevne = import_grapevne(workflow)
 globals().update(vars(grapevne))
 
+file_list = [
+    "genome_annotation.gff3",
+    "pathogen.json",
+    "reference.fasta",
+    "sequences.fasta",
+    "tree.json",
+]
+
 
 rule assign_serotype_and_genotype_nextclade:
     input:
-        dataset=resource("datasets/{serotype}"),
+        expand(
+            resource(
+                "datasets/{{serotype}}/{file}",
+            ),
+            file=file_list,
+        ),
         fasta=input("Unaligned_{serotype}.fasta"),
     output:
         csv=output("nextclade_output_{serotype}/nextclade.csv"),
     params:
         outdir=output("nextclade_output_{serotype}/"),
+        dataset=resource("datasets/{serotype}"),
     conda:
         env("nextstrain_all.yaml")
     log:
@@ -25,7 +39,7 @@ rule assign_serotype_and_genotype_nextclade:
         """
         mkdir -p {params.outdir}
         nextclade run \
-            --input-dataset {input.dataset} \
+            --input-dataset {params.dataset} \
             --output-all={params.outdir} \
             {input.fasta} > {log} 2>&1
         """

--- a/workflows/Dengue/modules/ProcessGenbankData/.test.sh
+++ b/workflows/Dengue/modules/ProcessGenbankData/.test.sh
@@ -4,10 +4,10 @@ if [ ! -d "results" ]; then
     mkdir results
 fi
 if [ ! -d "results/in" ]; then
-    ln -s ../../../sources/AcquireData/results/out results/in
+    ln -s ../../../sources/DownloadGenbank/results/out results/in
 fi
 if [ ! -d "results/in" ]; then
-    echo "No input data found. Please run the AcquireData pipeline first."
+    echo "No input data found. Please run the DownloadGenbank pipeline first."
     exit 1
 fi
 rm -rf results/out


### PR DESCRIPTION
Resource folder for the module AssignSerotypeAndGenotypeNextclade contained multiple files. These are now referenced individually in the Snakefile. An alternative implementation would be to support directory expansion in the `resource` wrapper (see https://github.com/kraemer-lab/grapevne-py/issues/20) although this is not yet implemented.